### PR TITLE
feat: fallback empty COMPOSE to null tex, deduplicate EMI from ALBD/BML

### DIFF
--- a/core/mdf_tex_processor_base.py
+++ b/core/mdf_tex_processor_base.py
@@ -260,6 +260,9 @@ def _compose_channels(slot_type, pbr_paths, pbr_channels, temp_dir, tex_name, pb
         loaded[pbr_type] = np.array(img.pixels[:], dtype=np.float32).reshape(ih, iw, 4)
         bpy.data.images.remove(img)
 
+    if not loaded:
+        return None
+
     if ref_w == 0:
         ref_w = ref_h = 1024
 
@@ -688,6 +691,11 @@ class MdfTexProcessBase(bpy.types.Operator):
                                   for pt in PBR_CHANNEL_SELECTABLE}
                 normal_flip_g  = mat_item.pbr.normal_flip_g
 
+                color_path    = pbr_paths.get('color', '')
+                emissive_path = pbr_paths.get('emissive', '')
+                share_emi     = bool(color_path and emissive_path and color_path == emissive_path)
+                albd_path_out = None
+
                 for slot in mat_item.slots:
                     if slot.mode == 'SKIP':
                         skip_count += 1
@@ -713,6 +721,14 @@ class MdfTexProcessBase(bpy.types.Operator):
                             skip_count += 1
                         continue
 
+                    if (slot.mode == 'COMPOSE'
+                            and slot.texture_type == 'EmissiveMap'
+                            and share_emi and albd_path_out):
+                        binding.path = albd_path_out
+                        print(f"[{cls._log_tag}] EMI reuse ALBD: {albd_path_out}")
+                        export_count += 1
+                        continue
+
                     try:
                         if slot.mode == 'COMPOSE':
                             src_img = _compose_channels(
@@ -721,8 +737,14 @@ class MdfTexProcessBase(bpy.types.Operator):
                                 channel_maps=cls._channel_maps,
                                 normal_flip_g=normal_flip_g)
                             if src_img is None:
-                                print(f"[{cls._log_tag}] SKIP compose {slot.texture_type}: no map")
-                                skip_count += 1
+                                null_rel = cls._null_tex_by_type.get(slot.texture_type)
+                                if null_rel:
+                                    binding.path = null_rel
+                                    print(f"[{cls._log_tag}] NULL (empty inputs) {slot.texture_type}: {null_rel}")
+                                    export_count += 1
+                                else:
+                                    print(f"[{cls._log_tag}] SKIP (empty inputs, no null) {slot.texture_type}")
+                                    skip_count += 1
                                 continue
                         else:  # DIRECT
                             src_img = bpy.path.abspath(slot.direct_image)
@@ -757,6 +779,8 @@ class MdfTexProcessBase(bpy.types.Operator):
                             DDSToTex([dds_path], cls._tex_version, disk_path)
 
                         binding.path = mdf_path
+                        if slot.texture_type == 'BaseDielectricMap':
+                            albd_path_out = mdf_path
                         print(f"[{cls._log_tag}] OK {slot.texture_type} -> {os.path.basename(disk_path)}")
                         export_count += 1
 

--- a/games/mhwi/mrl3_tex_processor.py
+++ b/games/mhwi/mrl3_tex_processor.py
@@ -354,6 +354,11 @@ class MHWI_OT_Mrl3TexProcess(bpy.types.Operator):
                                  for pt in PBR_CHANNEL_SELECTABLE}
                 normal_flip_g = mat_item.pbr.normal_flip_g
 
+                color_path    = pbr_paths.get('color', '')
+                emissive_path = pbr_paths.get('emissive', '')
+                share_emi     = bool(color_path and emissive_path and color_path == emissive_path)
+                bml_value_out = None
+
                 for slot in mat_item.slots:
                     if slot.mode == 'SKIP':
                         skip_count += 1
@@ -376,6 +381,14 @@ class MHWI_OT_Mrl3TexProcess(bpy.types.Operator):
                             skip_count += 1
                         continue
 
+                    if (slot.mode == 'COMPOSE'
+                            and slot.texture_type == 'EmissiveMap'
+                            and share_emi and bml_value_out):
+                        map_item.value = bml_value_out
+                        print(f"[MHWI Tex] EMI reuse BML: {bml_value_out}")
+                        export_count += 1
+                        continue
+
                     # COMPOSE or DIRECT
                     try:
                         if slot.mode == 'COMPOSE':
@@ -391,9 +404,14 @@ class MHWI_OT_Mrl3TexProcess(bpy.types.Operator):
                                 normal_flip_g=normal_flip_g,
                             )
                             if src_img is None:
-                                print(f"[MHWI Tex] SKIP  {slot.texture_type}: "
-                                      "无 PBR 输入图片")
-                                skip_count += 1
+                                null_val = MHWI_NULL_TEX.get(slot.texture_type)
+                                if null_val:
+                                    map_item.value = null_val
+                                    print(f"[MHWI Tex] NULL (empty inputs) {slot.texture_type}: {null_val}")
+                                    export_count += 1
+                                else:
+                                    print(f"[MHWI Tex] SKIP  {slot.texture_type}: 无 PBR 输入图片")
+                                    skip_count += 1
                                 continue
                         else:  # DIRECT
                             src_img = bpy.path.abspath(slot.direct_image)
@@ -435,6 +453,8 @@ class MHWI_OT_Mrl3TexProcess(bpy.types.Operator):
 
                         map_item.value = _mhwi_tex_binding(
                             base_path, tex_name, slot.texture_type)
+                        if slot.texture_type == 'AlbedoMap':
+                            bml_value_out = map_item.value
                         print(f"[MHWI Tex] OK    {slot.texture_type} -> "
                               f"{os.path.basename(disk_path)}")
                         export_count += 1


### PR DESCRIPTION
- _compose_channels returns None when no PBR inputs are loaded
- COMPOSE slots with no inputs now write the game null tex path instead of generating a solid-color placeholder
- EmissiveMap in COMPOSE mode reuses the AlbedoMap/BML output path when color and emissive inputs are identical (toon workflow)
- Applied to both RE Engine MDF and MHWI MRL3 processors