### PR TITLE
2.5.1: batch chain creation performance, and auto preset detection via standard bone coverage.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Modding Toolkit",
     "author": "Dimcirui",
-    "version": (2, 5, 0),
+    "version": (2, 5, 1),
     "blender": (3, 0, 0),
     "location": "View3D > Sidebar > MOD Toolkit",
     "description": "Modding Toolkit for Capcom's games",

--- a/core/bone_mapper.py
+++ b/core/bone_mapper.py
@@ -160,11 +160,9 @@ def _list_preset_files(is_import_x):
 
 
 def auto_detect_preset(armature_obj, is_import_x):
-    """遍历所有预设文件，对每个预设做模糊骨骼匹配，返回覆盖率最高的文件名。
-    覆盖率 >= 95% 才视为匹配成功，否则返回 None。"""
-    all_bones = {b.name for b in armature_obj.data.bones}
-    if not all_bones:
-        return None
+    """遍历所有预设文件，对每个预设在骨架的 47 个标准骨骼上做匹配测试，
+    返回覆盖率最高的文件名。覆盖率 >= 95% 才视为匹配成功，否则返回 None。"""
+    from .ui_config import OPTIONAL_BONES
 
     best_preset = None
     best_ratio = 0.0
@@ -174,17 +172,16 @@ def auto_detect_preset(armature_obj, is_import_x):
         if not mapper.load_preset(filename, is_import_x):
             continue
 
-        preset_bones = set()
-        for std_key in mapper.mapping_data:
-            main_actual, aux_actuals = mapper.get_matches_for_standard(armature_obj, std_key)
-            if main_actual:
-                preset_bones.add(main_actual)
-            preset_bones.update(aux_actuals)
-        preset_bones.update(mapper.exclude_bones & all_bones)
+        total = 0
+        matched = 0
+        for std_key in STANDARD_BONE_NAMES:
+            if std_key in OPTIONAL_BONES:
+                continue
+            total += 1
+            main, _ = mapper.get_matches_for_standard(armature_obj, std_key)
+            if main:
+                matched += 1
 
-        exclude_in_arm = mapper.exclude_bones & all_bones
-        total = len(all_bones - exclude_in_arm)
-        matched = len(preset_bones - exclude_in_arm)
         if total == 0:
             continue
         ratio = matched / total

--- a/core/bone_mapper.py
+++ b/core/bone_mapper.py
@@ -146,3 +146,52 @@ class BoneMapManager:
     def get_standard_from_game(self, game_bone_name):
         """输入 MhBone_013 -> 返回 pelvis"""
         return self.reverse_mapping.get(game_bone_name, None)
+
+
+def _list_preset_files(is_import_x):
+    """返回预设目录下所有 .json 文件名列表"""
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    root_dir = os.path.dirname(current_dir)
+    sub_dir = os.path.join("presets", "import" if is_import_x else "bone")
+    preset_dir = os.path.join(root_dir, "assets", sub_dir)
+    if not os.path.exists(preset_dir):
+        return []
+    return sorted(f for f in os.listdir(preset_dir) if f.endswith('.json'))
+
+
+def auto_detect_preset(armature_obj, is_import_x):
+    """遍历所有预设文件，对每个预设做模糊骨骼匹配，返回覆盖率最高的文件名。
+    覆盖率 >= 95% 才视为匹配成功，否则返回 None。"""
+    all_bones = {b.name for b in armature_obj.data.bones}
+    if not all_bones:
+        return None
+
+    best_preset = None
+    best_ratio = 0.0
+
+    for filename in _list_preset_files(is_import_x):
+        mapper = BoneMapManager()
+        if not mapper.load_preset(filename, is_import_x):
+            continue
+
+        preset_bones = set()
+        for std_key in mapper.mapping_data:
+            main_actual, aux_actuals = mapper.get_matches_for_standard(armature_obj, std_key)
+            if main_actual:
+                preset_bones.add(main_actual)
+            preset_bones.update(aux_actuals)
+        preset_bones.update(mapper.exclude_bones & all_bones)
+
+        exclude_in_arm = mapper.exclude_bones & all_bones
+        total = len(all_bones - exclude_in_arm)
+        matched = len(preset_bones - exclude_in_arm)
+        if total == 0:
+            continue
+        ratio = matched / total
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best_preset = filename
+        if ratio >= 1.0:
+            break
+
+    return best_preset if best_ratio >= 0.95 else None

--- a/core/bone_utils.py
+++ b/core/bone_utils.py
@@ -225,10 +225,12 @@ def get_preset_items(subdir):
 
 def get_import_presets_callback(self, context):
     _import_preset_cache.clear()
+    _import_preset_cache.append(("AUTO", "自动识别", "根据骨架骨骼覆盖率自动选择最匹配的预设"))
     _import_preset_cache.extend(get_preset_items("presets/import"))
     return _import_preset_cache
 
 def get_target_presets_callback(self, context):
     _target_preset_cache.clear()
+    _target_preset_cache.append(("AUTO", "自动识别", "根据骨架骨骼覆盖率自动选择最匹配的预设"))
     _target_preset_cache.extend(get_preset_items("presets/bone"))
     return _target_preset_cache

--- a/games/mhwi/operators.py
+++ b/games/mhwi/operators.py
@@ -1,9 +1,24 @@
+import sys
+import time
 import bpy
 import re
 from bpy.app.translations import pgettext as _
 from ...core import bone_utils
 from ...core.bone_mapper import BoneMapManager
 from ...core.standard_ops import _build_fuzzy_preset_bones
+
+
+def _patch_chain_cleanup(disable=True):
+    saved = []
+    for mod in sys.modules.values():
+        has_align = hasattr(mod, 'alignChains') and callable(mod.alignChains)
+        has_color = hasattr(mod, 'setChainBoneColor') and callable(mod.setChainBoneColor)
+        if has_align and has_color:
+            saved.append((mod, mod.alignChains, mod.setChainBoneColor))
+            if disable:
+                mod.alignChains = lambda: None
+                mod.setChainBoneColor = lambda x: None
+    return saved
 
 
 def _is_mhwi_physics(name):
@@ -134,6 +149,8 @@ class MHWI_OT_AutoCreateChains(bpy.types.Operator):
         self.layout.prop(self, "ctc_collection")
 
     def execute(self, context):
+        t_total = time.perf_counter()
+
         col = bpy.data.collections.get(self.ctc_collection)
         if col is None:
             self.report({'ERROR'}, _("找不到集合: %s") % self.ctc_collection)
@@ -169,29 +186,59 @@ class MHWI_OT_AutoCreateChains(bpy.types.Operator):
             self.report({'WARNING'}, _("未找到链首骨骼（chain_role=head/branch_head），请先刷新骨骼颜色"))
             return {'CANCELLED'}
 
+        print(f"[ChainGen CTC] {len(chain_heads)} heads -> {len(chain_heads)} chains (linear only)",
+              file=sys.stderr)
+
+        # monkey-patch MHW Model Editor 的 alignChains() / setChainBoneColor()
+        _patches = _patch_chain_cleanup(disable=True)
+
         created = 0
         skipped_existing = 0
         skipped_branch = []
 
-        for head_pb in chain_heads:
-            if head_pb.name in existing_heads:
-                skipped_existing += 1
-                continue
+        t_loop = time.perf_counter()
+        try:
+            for idx, head_pb in enumerate(chain_heads, 1):
+                if head_pb.name in existing_heads:
+                    skipped_existing += 1
+                    continue
 
-            if _has_branch(head_pb, physics_bones, armature):
-                skipped_branch.append(head_pb.name)
-                continue
+                if _has_branch(head_pb, physics_bones, armature):
+                    skipped_branch.append(head_pb.name)
+                    print(f"[ChainGen CTC] Chain {idx:3d}/{len(chain_heads)}  skipped (branch)  head={head_pb.name}",
+                          file=sys.stderr)
+                    continue
 
-            # 选中链头骨骼并调用 CTC chain 创建算子
-            bpy.ops.pose.select_all(action='DESELECT')
-            head_pb.bone.select = True
-            armature.data.bones.active = head_pb.bone
+                # 选中链头骨骼并调用 CTC chain 创建算子
+                bpy.ops.pose.select_all(action='DESELECT')
+                head_pb.bone.select = True
+                armature.data.bones.active = head_pb.bone
 
-            result = bpy.ops.mhw_ctc.create_chain_from_bone()
-            if result == {'FINISHED'}:
-                created += 1
-            else:
-                skipped_branch.append(head_pb.name)  # 创建失败也归入跳过
+                t0 = time.perf_counter()
+                result = bpy.ops.mhw_ctc.create_chain_from_bone()
+                t_chain = time.perf_counter() - t0
+
+                if result == {'FINISHED'}:
+                    created += 1
+                else:
+                    skipped_branch.append(head_pb.name)
+
+                bones = sum(1 for _ in armature.pose.bones.get(head_pb.name).children_recursive) + 1 if armature.pose.bones.get(head_pb.name) else "?"
+                print(f"[ChainGen CTC] Chain {idx:3d}/{len(chain_heads)}  "
+                      f"create={t_chain:.4f}s  bones~{bones}  head={head_pb.name}",
+                      file=sys.stderr)
+        finally:
+            _patch_chain_cleanup(disable=False)
+            if _patches and created > 0:
+                mod, _align, _color = _patches[0]
+                _align()
+                _color(armature)
+
+        t_loop = time.perf_counter() - t_loop
+        t_total = time.perf_counter() - t_total
+        print(f"[ChainGen CTC] --- loop: {t_loop:.4f}s  total: {t_total:.4f}s  "
+              f"created={created}  skipped_existing={skipped_existing}  skipped_branch={len(skipped_branch)} ---",
+              file=sys.stderr)
 
         # 汇报结果
         msg_parts = [_("已创建 %d 条链") % created]

--- a/games/mhws/operators.py
+++ b/games/mhws/operators.py
@@ -1,3 +1,5 @@
+import sys
+import time
 import bpy
 from bpy.app.translations import pgettext as _
 from ...core import weight_utils
@@ -338,6 +340,23 @@ def _get_chain_col_items(self, context):
     return _chain_col_items
 
 
+def _patch_chain_cleanup(disable=True):
+    """搜索 sys.modules 中所有持有 alignChains + setChainBoneColor 可调用函数的模块，
+    批量替换为 no-op（disable=True）或恢复原始函数（disable=False）。
+    RE-Chain-Editor 里 re_chain_operators 通过 from import 持有副本引用，
+    单 patch 一个模块不够，必须批量覆盖所有引用点。"""
+    saved = []
+    for mod in sys.modules.values():
+        has_align = hasattr(mod, 'alignChains') and callable(mod.alignChains)
+        has_color = hasattr(mod, 'setChainBoneColor') and callable(mod.setChainBoneColor)
+        if has_align and has_color:
+            saved.append((mod, mod.alignChains, mod.setChainBoneColor))
+            if disable:
+                mod.alignChains = lambda: None
+                mod.setChainBoneColor = lambda x: None
+    return saved
+
+
 class MHWS_OT_AutoCreateChains(bpy.types.Operator):
     """在姿态模式下，根据物理骨骼的 chain_role 属性自动为每条链创建 Chain Settings 和 Chain Group。
 支持分叉物理链，分叉链使用实验模式生成，线性链使用默认模式生成。
@@ -357,7 +376,7 @@ class MHWS_OT_AutoCreateChains(bpy.types.Operator):
             ('SEPARATE', "各自独立", "每条链拥有独立的 Chain Settings"),
             ('SHARED',   "共享同一", "所有链共用同一个 Chain Settings"),
         ],
-        default='SEPARATE',
+        default='SHARED',
     )
 
     @classmethod
@@ -394,6 +413,8 @@ class MHWS_OT_AutoCreateChains(bpy.types.Operator):
         layout.prop(self, "settings_mode", expand=True)
 
     def execute(self, context):
+        t_total = time.perf_counter()
+
         col = bpy.data.collections.get(self.chain_collection)
         # 脚本直调时 chain_collection enum 拿不到值，fallback 到 toolpanel 已设的集合
         if col is None:
@@ -436,11 +457,16 @@ class MHWS_OT_AutoCreateChains(bpy.types.Operator):
         physics_bones = {b.name for b in armature.data.bones if b.name not in preset_bones}
 
         # 将所有链头分解为线性路径：[(head_pb, paths, path), ...]
+        t_decompose = time.perf_counter()
         all_entries = []
         for head_pb in chain_heads:
             paths = _decompose_chains(head_pb, armature, physics_bones)
             for path in paths:
                 all_entries.append((head_pb, paths, path))
+        t_decompose = time.perf_counter() - t_decompose
+        print(f"[ChainGen] _decompose_chains: {t_decompose:.4f}s  "
+              f"({len(chain_heads)} heads -> {len(all_entries)} paths)",
+              file=sys.stderr)
 
         created = 0
         skipped = 0
@@ -451,38 +477,58 @@ class MHWS_OT_AutoCreateChains(bpy.types.Operator):
                 return {'CANCELLED'}
 
         saved_experimental = getattr(toolpanel, 'experimentalPoseModeOptions', False)
+
+        # monkey-patch RE-Chain-Editor 的 alignChains() / setChainBoneColor()
+        # 批量替换所有引用点为 no-op，避免每条链创建后 O(n) 扫描全体对象
+        _patches = _patch_chain_cleanup(disable=True)
+
+        t_loop = time.perf_counter()
         try:
-            for head_pb, head_paths, path in all_entries:
+            for idx, (head_pb, head_paths, path) in enumerate(all_entries, 1):
+                t_settings = 0.0
                 if self.settings_mode == 'SEPARATE':
+                    t0 = time.perf_counter()
                     if bpy.ops.re_chain.create_chain_settings() != {'FINISHED'}:
                         skipped += 1
                         continue
+                    t_settings = time.perf_counter() - t0
 
                 bpy.ops.pose.select_all(action='DESELECT')
-                use_experimental = len(head_paths) > 1
+                # _decompose_chains 已提供精确的物理骨骼路径，统一走 exp 模式
+                # 避免 norm 模式的 children_recursive 扫到非物理子骨分叉导致失败
+                for bone_name in path:
+                    pb2 = armature.pose.bones.get(bone_name)
+                    if pb2:
+                        pb2.bone.select = True
+                first_pb = armature.pose.bones.get(path[0]) if path else None
+                if first_pb:
+                    armature.data.bones.active = first_pb.bone
+                toolpanel.experimentalPoseModeOptions = True
 
-                if use_experimental:
-                    # 分支链：实验模式，选中路径上的全部骨骼
-                    for bone_name in path:
-                        pb2 = armature.pose.bones.get(bone_name)
-                        if pb2:
-                            pb2.bone.select = True
-                    first_pb = armature.pose.bones.get(path[0]) if path else None
-                    if first_pb:
-                        armature.data.bones.active = first_pb.bone
-                    toolpanel.experimentalPoseModeOptions = True
-                else:
-                    # 线性链：默认模式，只选链头
-                    head_pb.bone.select = True
-                    armature.data.bones.active = head_pb.bone
-                    toolpanel.experimentalPoseModeOptions = False
-
+                t0 = time.perf_counter()
                 if bpy.ops.re_chain.chain_from_bone() == {'FINISHED'}:
                     created += 1
                 else:
                     skipped += 1
+                t_chain = time.perf_counter() - t0
+
+                print(f"[ChainGen] Chain {idx:3d}/{len(all_entries)}  "
+                      f"settings={t_settings:.4f}s  create={t_chain:.4f}s  "
+                      f"bones={len(path):2d}",
+                      file=sys.stderr)
         finally:
+            _patch_chain_cleanup(disable=False)
+            if _patches and created > 0:
+                mod, _align, _color = _patches[0]
+                _align()
+                _color(armature)
             toolpanel.experimentalPoseModeOptions = saved_experimental
+
+        t_loop = time.perf_counter() - t_loop
+        t_total = time.perf_counter() - t_total
+        print(f"[ChainGen] --- loop: {t_loop:.4f}s  total: {t_total:.4f}s  "
+              f"created={created}  skipped={skipped} ---",
+              file=sys.stderr)
 
         self.report({'INFO'}, _("已创建 %d 条链，跳过 %d 条") % (created, skipped))
         return {'FINISHED'}

--- a/ui/main_panel.py
+++ b/ui/main_panel.py
@@ -17,6 +17,32 @@ from ..core.bone_mapper import BoneMapManager
 # 映射详情预览缓存：{(x_preset, y_preset): (mapper_x, mapper_y)}
 _mapping_detail_cache = {}
 
+def _on_auto_preset_update(self, context, is_import_x):
+    """选中 'AUTO' 时自动检测最匹配的预设，直接替换枚举值"""
+    attr = 'import_preset_enum' if is_import_x else 'target_preset_enum'
+    if getattr(self, attr) != 'AUTO':
+        return
+    arm = context.active_object
+    if not arm or arm.type != 'ARMATURE':
+        self.report({'WARNING'}, "自动识别需要选中骨架")
+        return
+    from ..core.bone_mapper import auto_detect_preset
+    result = auto_detect_preset(arm, is_import_x)
+    if result:
+        setattr(self, attr, result)
+    else:
+        self.report({'WARNING'}, "自动识别失败，未找到完全覆盖骨架的预设，请手动选择")
+
+def _on_auto_import_update(self, context):
+    _on_auto_preset_update(self, context, True)
+
+def _on_auto_target_update(self, context):
+    _on_auto_preset_update(self, context, False)
+
+def _on_auto_pose_update(self, context):
+    _on_auto_preset_update(self, context, True)
+
+
 class MHW_PT_SuiteSettings(bpy.types.PropertyGroup):
     # 顶部开关
     show_mhwi: bpy.props.BoolProperty(name="MHWI", default=False)
@@ -35,13 +61,15 @@ class MHW_PT_SuiteSettings(bpy.types.PropertyGroup):
     import_preset_enum: bpy.props.EnumProperty(
         name="来源预设 (X)",
         description="选择导入模型的骨架结构",
-        items=get_import_presets_callback
+        items=get_import_presets_callback,
+        update=_on_auto_import_update
     )
     
     target_preset_enum: bpy.props.EnumProperty(
         name="目标游戏 (Y)",
         description="选择要导出的目标游戏",
-        items=get_target_presets_callback
+        items=get_target_presets_callback,
+        update=_on_auto_target_update
     )
     
     show_mapping_details: bpy.props.BoolProperty(name="显示映射细节", default=False)
@@ -62,7 +90,8 @@ class MHW_PT_SuiteSettings(bpy.types.PropertyGroup):
     pose_import_preset_enum: bpy.props.EnumProperty(
         name="骨架预设",
         description="用于识别骨骼名称的预设",
-        items=get_import_presets_callback
+        items=get_import_presets_callback,
+        update=_on_auto_pose_update
     )
     
     # 姿态记录文件选择

--- a/ui/main_panel.py
+++ b/ui/main_panel.py
@@ -1,4 +1,5 @@
 import bpy
+import os
 from bpy.app.translations import pgettext as _
 from ..core import bone_utils, weight_utils, ui_config
 from ..core.bone_utils import get_import_presets_callback, get_target_presets_callback
@@ -17,30 +18,26 @@ from ..core.bone_mapper import BoneMapManager
 # 映射详情预览缓存：{(x_preset, y_preset): (mapper_x, mapper_y)}
 _mapping_detail_cache = {}
 
-def _on_auto_preset_update(self, context, is_import_x):
+def _on_auto_preset_update(self, context, is_import_x, attr_name):
     """选中 'AUTO' 时自动检测最匹配的预设，直接替换枚举值"""
-    attr = 'import_preset_enum' if is_import_x else 'target_preset_enum'
-    if getattr(self, attr) != 'AUTO':
+    if getattr(self, attr_name) != 'AUTO':
         return
     arm = context.active_object
     if not arm or arm.type != 'ARMATURE':
-        self.report({'WARNING'}, "自动识别需要选中骨架")
         return
     from ..core.bone_mapper import auto_detect_preset
     result = auto_detect_preset(arm, is_import_x)
     if result:
-        setattr(self, attr, result)
-    else:
-        self.report({'WARNING'}, "自动识别失败，未找到完全覆盖骨架的预设，请手动选择")
+        setattr(self, attr_name, result)
 
 def _on_auto_import_update(self, context):
-    _on_auto_preset_update(self, context, True)
+    _on_auto_preset_update(self, context, True, 'import_preset_enum')
 
 def _on_auto_target_update(self, context):
-    _on_auto_preset_update(self, context, False)
+    _on_auto_preset_update(self, context, False, 'target_preset_enum')
 
 def _on_auto_pose_update(self, context):
-    _on_auto_preset_update(self, context, True)
+    _on_auto_preset_update(self, context, True, 'pose_import_preset_enum')
 
 
 class MHW_PT_SuiteSettings(bpy.types.PropertyGroup):
@@ -509,8 +506,16 @@ class MHW_PT_MainPanel(bpy.types.Panel):
 
         if settings.show_std_converter:
             col = main_box.column(align=True)
-            col.prop(settings, "import_preset_enum", icon='IMPORT')
-            col.prop(settings, "target_preset_enum", icon='EXPORT')
+            row = col.row(align=True)
+            row.prop(settings, "import_preset_enum", icon='IMPORT')
+            op = row.operator("modder.auto_detect_preset", text="", icon='VIEWZOOM')
+            op.attr_name = 'import_preset_enum'
+            op.is_import_x = True
+            row = col.row(align=True)
+            row.prop(settings, "target_preset_enum", icon='EXPORT')
+            op = row.operator("modder.auto_detect_preset", text="", icon='VIEWZOOM')
+            op.attr_name = 'target_preset_enum'
+            op.is_import_x = False
             
             col.separator()
             
@@ -619,7 +624,11 @@ class MHW_PT_MainPanel(bpy.types.Panel):
         if settings.show_pose_convert:
             col = pose_box.column(align=True)
             
-            col.prop(settings, "pose_import_preset_enum", text="骨架预设", icon='IMPORT')
+            row = col.row(align=True)
+            row.prop(settings, "pose_import_preset_enum", text="骨架预设", icon='IMPORT')
+            op = row.operator("modder.auto_detect_preset", text="", icon='VIEWZOOM')
+            op.attr_name = 'pose_import_preset_enum'
+            op.is_import_x = True
             
             col.separator()
             col.label(text="简易工具:")
@@ -772,6 +781,36 @@ classes = [
     MHW_OT_GeneralTools,
     MHW_PT_MainPanel,
 ]
+
+
+class MODDER_OT_AutoDetectPreset(bpy.types.Operator):
+    """检测当前选中骨架的骨骼覆盖率，自动匹配最合适的预设"""
+    bl_idname = "modder.auto_detect_preset"
+    bl_label = "识别预设"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    attr_name: bpy.props.StringProperty()
+    is_import_x: bpy.props.BoolProperty(default=True)
+
+    def execute(self, context):
+        arm = context.active_object
+        if not arm or arm.type != 'ARMATURE':
+            self.report({'WARNING'}, "请先选中骨架")
+            return {'CANCELLED'}
+
+        from ..core.bone_mapper import auto_detect_preset
+        result = auto_detect_preset(arm, self.is_import_x)
+        if result:
+            settings = context.scene.mhw_suite_settings
+            setattr(settings, self.attr_name, result)
+            display = os.path.splitext(result)[0]
+            self.report({'INFO'}, f"已识别: {display}")
+        else:
+            self.report({'WARNING'}, "未找到覆盖率 >= 95% 的预设，请手动选择")
+        return {'FINISHED'}
+
+
+classes.append(MODDER_OT_AutoDetectPreset)
 
 def register():
     for cls in classes:


### PR DESCRIPTION
### Overview
Two independent improvements:
1. **Batch chain creation performance** — defer `alignChains()` / `setChainBoneColor()` O(n²) scanning
2. **Auto preset detection** — based on standard bone coverage, with UI button fallback
---
### 1. perf: Batch chain creation — defer `alignChains()` / `setChainBoneColor()`
**Problem**
RE-Chain-Editor and MHW Model Editor both call `alignChains()` and
`setChainBoneColor()` at the end of every `chain_from_bone()`. These
functions iterate **all scene objects** looking for chain nodes and
trigger `view_layer.update()` per chain. When batch-creating N chains:
Chain   1 → alignChains (scan 1 chain)  + view_layer.update   ≈ 0.9s
Chain  75 → alignChains (scan 75 chains) + view_layer.update  ≈ 3.2s
Chain 200 → alignChains (scan 200 chains) + view_layer.update ≈ 2.0s
Additionally, `re_chain_operators` holds `from import` references to these
functions. Patching `blender_re_chain.alignChains` alone missed the
operator module's local copy.
**Solution**
- `_patch_chain_cleanup(disable=True/False)` — searches **all** modules
  in `sys.modules` for `alignChains` / `setChainBoneColor` callables
  (using `callable()` to filter modules vs functions), swaps to no-ops
  during the batch loop, restores originals in `finally` and calls them
  once after all chains are done.
- Unified all chains to exp mode — `_decompose_chains()` already
  provides exact linear paths from `chain_role` annotations. Passing
  these directly to `chain_from_bone()` avoids norm mode's
  `children_recursive`, which fails when non-physics child bones create
  spurious branching.
- Default `settings_mode` to `SHARED` to avoid per-chain
  `checkNameUsage()` O(n) scans.
**Files:** `games/mhws/operators.py`, `games/mhwi/operators.py`
---
### 2. feat: Auto preset detection via standard bone coverage + UI button
**Problem**
Users must manually select the correct X/Y skeleton preset from 14+
options. Wrong selection causes silent mapping failures.
**Solution**
`auto_detect_preset(armature, is_import_x)` in `bone_mapper.py`:
```python
def auto_detect_preset(armature_obj, is_import_x):
    from .ui_config import OPTIONAL_BONES
    best_preset = None
    best_ratio = 0.0
    for filename in _list_preset_files(is_import_x):
        total = 0; matched = 0
        for std_key in STANDARD_BONE_NAMES:
            if std_key in OPTIONAL_BONES:
                continue
            total += 1
            main, _ = mapper.get_matches_for_standard(armature_obj, std_key)
            if main:
                matched += 1
        ratio = matched / total
        ...
    return best_preset if best_ratio >= 0.95 else None
- Iterates 46 standard bones (47 minus OPTIONAL_BONES spine_03),
mirrors the "mapping detail" preview logic exactly.
- "AUTO" item prepended to get_import_presets_callback() /
get_target_presets_callback() enum lists.
- update= callbacks on all 3 preset EnumProperties (import, target,
pose): selecting "AUTO" triggers detection and
setattr(settings, attr, result), replacing the enum value instantly.
- MODDER_OT_AutoDetectPreset operator — VIEWZOOM icon button next to
each dropdown as manual fallback.
Files: core/bone_mapper.py, core/bone_utils.py, ui/main_panel.py

Changelog
6e5a8f9 perf: monkey-patch alignChains/setChainBoneColor in batch chain creation
f207a42 feat: simple AUTO preset detection via enum update callback
ed56ed2 fix: AUTO callback crash + add detect button next to preset dropdowns
5eafd33 fix: auto_detect_preset uses STANDARD_BONE_NAMES for coverage