### PR TITLE
2.5.1 hotfix1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Modding Toolkit",
     "author": "Dimcirui",
-    "version": (2, 5, 1),
+    "version": (2, 5, 1, 1),
     "blender": (3, 0, 0),
     "location": "View3D > Sidebar > MOD Toolkit",
     "description": "Modding Toolkit for Capcom's games",

--- a/core/standard_ops.py
+++ b/core/standard_ops.py
@@ -867,6 +867,13 @@ class MODDER_OT_RefreshPhysicsBoneColors(bpy.types.Operator):
         bpy.context.view_layer.objects.active = arm_obj
         bpy.ops.object.mode_set(mode='POSE')
         _detect_chain_roles(arm_obj, preset_bones)
+        for b in arm_obj.data.bones:
+            if b.name in preset_bones:
+                pb = arm_obj.pose.bones.get(b.name)
+                if pb:
+                    if "chain_role" in pb:
+                        del pb["chain_role"]
+                    pb.color.palette = 'DEFAULT'
         _apply_physics_bone_colors(arm_obj, preset_bones)
         if detected:
             self.report({'INFO'}, _("骨骼颜色已刷新（自动识别预设：%s）") % detected)

--- a/core/standard_ops.py
+++ b/core/standard_ops.py
@@ -1,6 +1,6 @@
 import bpy, mathutils
 from bpy.app.translations import pgettext as _
-from .bone_mapper import BoneMapManager, STANDARD_BONE_NAMES, _normalize_bone_name
+from .bone_mapper import BoneMapManager, STANDARD_BONE_NAMES, _normalize_bone_name, auto_detect_preset
 from . import weight_utils, bone_utils
 
 
@@ -851,15 +851,27 @@ class MODDER_OT_RefreshPhysicsBoneColors(bpy.types.Operator):
             return {'CANCELLED'}
         settings = context.scene.mhw_suite_settings
         mapper = BoneMapManager()
-        if not mapper.load_preset(settings.import_preset_enum, is_import_x=True):
-            self.report({'ERROR'}, _("无法加载 X 预设"))
-            return {'CANCELLED'}
+
+        detected = auto_detect_preset(arm_obj, is_import_x=True)
+        if detected:
+            if not mapper.load_preset(detected, is_import_x=True):
+                self.report({'ERROR'}, _("无法加载自动识别的预设"))
+                return {'CANCELLED'}
+        else:
+            if not mapper.load_preset(settings.import_preset_enum, is_import_x=True):
+                self.report({'ERROR'}, _("无法加载 X 预设"))
+                return {'CANCELLED'}
+            self.report({'WARNING'}, _("未能自动识别目标游戏预设，回退至来源预设 [%s]，建议手动切换") % settings.import_preset_enum)
+
         preset_bones = _build_fuzzy_preset_bones(mapper, arm_obj)
         bpy.context.view_layer.objects.active = arm_obj
         bpy.ops.object.mode_set(mode='POSE')
         _detect_chain_roles(arm_obj, preset_bones)
         _apply_physics_bone_colors(arm_obj, preset_bones)
-        self.report({'INFO'}, _("骨骼颜色已刷新"))
+        if detected:
+            self.report({'INFO'}, _("骨骼颜色已刷新（自动识别预设：%s）") % detected)
+        else:
+            self.report({'INFO'}, _("骨骼颜色已刷新"))
         return {'FINISHED'}
 
 

--- a/games/mhwi/operators.py
+++ b/games/mhwi/operators.py
@@ -726,6 +726,8 @@ class MHWI_OT_BatchRenamePhysicsBones(bpy.types.Operator):
         layout.label(
             text=_("当前超出了 %d 个骨骼，建议先简化骨骼后再进行命名。") % self._fail_count)
         layout.label(text=_("确定仍然进行重命名？"))
+
+    def execute(self, context):
         mapper = BoneMapManager()
         if not mapper.load_preset("怪猎世界.json", is_import_x=True):
             self.report({'ERROR'}, _("无法加载怪猎世界预设"))

--- a/ui/main_panel.py
+++ b/ui/main_panel.py
@@ -551,7 +551,7 @@ class MHW_PT_MainPanel(bpy.types.Panel):
                 row = exp_col.row(align=True)
                 row.operator("modder.mark_as_main_continue", text=_("标记为主链延伸"), icon='HANDLE_ALIGNED')
                 row.operator("modder.clear_chain_role", text=_("清除标记"), icon='X')
-                exp_col.operator("modder.refresh_physics_bone_colors", text=_("刷新骨骼颜色 [X]"), icon='COLOR')
+                exp_col.operator("modder.refresh_physics_bone_colors", text=_("刷新骨骼颜色"), icon='COLOR')
                 exp_col.separator()
                 row = exp_col.row(align=True)
                 row.label(text="骨骼显示 [X]:", icon='HIDE_OFF')


### PR DESCRIPTION
This pull request introduces improvements to the bone preset detection and color refresh workflow in the Modding Toolkit, aiming to enhance user experience and error handling when working with armature presets. The main focus is on adding automatic preset detection and providing clearer feedback to users if auto-detection fails, as well as minor UI and versioning updates.

**Bone preset detection and color refresh improvements:**

* Added automatic preset detection with `auto_detect_preset` in `core/standard_ops.py`. If detection fails, the system falls back to the user-selected preset and provides a warning to the user. [[1]](diffhunk://#diff-d2514775d5fa9a8251bdbe8747875445a40dfdf12356d7751ffd2d14befc3aa3L3-R3) [[2]](diffhunk://#diff-d2514775d5fa9a8251bdbe8747875445a40dfdf12356d7751ffd2d14befc3aa3R854-R880)
* Enhanced bone color refresh logic: after applying the preset, bone colors are updated and relevant status messages are reported, indicating whether auto-detection succeeded or fallback occurred.

**UI and user feedback updates:**

* Updated the UI label for the bone color refresh button in `ui/main_panel.py` by removing the "[X]" suffix for clarity.
* Improved user feedback by reporting warnings when auto-detection fails and info messages when bone colors are refreshed, specifying the detected preset if applicable.

**Other changes:**

* Incremented the add-on version number in `__init__.py` to `(2, 5, 1, 1)` to reflect these updates.
* Minor code structure update in `games/mhwi/operators.py` to add an `execute` method (likely a bugfix or preparation for further logic).