### PR TITLE
2.6.2: bug fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Modding Toolkit",
     "author": "Dimcirui",
-    "version": (2, 6, 0),
+    "version": (2, 6, 2),
     "blender": (3, 0, 0),
     "location": "View3D > Sidebar > MOD Toolkit",
     "description": "Modding Toolkit for Capcom's games",

--- a/assets/export_schemes/re4/re4_ada.json
+++ b/assets/export_schemes/re4/re4_ada.json
@@ -7,6 +7,7 @@
         "_Mercenaries/Character/ch/cha8/cha800.fbxskel.5"
     ],
     "native_skeleton": "ada.fbxskel.5",
+    "body_groups_for_fbxskel": ["本体 身体(00)", "DLC 身体(00)"],
     "groups": [
         {
             "name": "本体 身体(00)",

--- a/assets/export_schemes/re4/re4_ashley.json
+++ b/assets/export_schemes/re4/re4_ashley.json
@@ -7,6 +7,7 @@
     "_Chainsaw/Character/ch/cha1/cha1z0.fbxskel.5"
   ],
   "native_skeleton": "ashley.fbxskel.5",
+  "body_groups_for_fbxskel": ["身体(00)"],
   "groups": [
     {
       "name": "身体(00)",

--- a/assets/export_schemes/re4/re4_leon.json
+++ b/assets/export_schemes/re4/re4_leon.json
@@ -4,6 +4,7 @@
   "base_path": "STM/_Chainsaw/Character/ch/cha0",
   "fbxskel": "_Chainsaw/Character/ch/cha0/cha000.skeleton.5",
   "native_skeleton": "leon.skeleton.5",
+  "body_groups_for_fbxskel": ["身体(00)"],
   "groups": [
     {
       "name": "身体(00)",

--- a/core/editor_ops.py
+++ b/core/editor_ops.py
@@ -126,6 +126,11 @@ class MODDER_OT_MirrorMapping(bpy.types.Operator):
         def get_mirrored_name(name):
             if not name: return None
             new_name = name
+            # Handle L_/l_ prefix style (RE Engine: L_BoneName, HD2: l_bonename)
+            if new_name.startswith("L_"):
+                return "R_" + new_name[2:]
+            if new_name.startswith("l_"):
+                return "r_" + new_name[2:]
             basic_replacements = [
                 ("_L_", "_R_"), ("_L.", "_R."), ("_L", "_R"),
                 (".L", ".R"), (" L ", " R "),

--- a/games/mhws/operators.py
+++ b/games/mhws/operators.py
@@ -465,7 +465,36 @@ _PREPROCESS_ARM_SLOTS = (
     "forearm_L",  "forearm_R",
     "hand_L",     "hand_R",
 )
-_PREPROCESS_Y_PRESET = "怪猎荒野.json"
+def _detect_mhws_y_preset(ref_arm_obj=None):
+    """Detect the MHWS bone (Y) preset filename.
+
+    Primary:  scan presets/bone/ for the first JSON whose preset_info.game_code
+              equals 'MHWS' (filename-agnostic, survives renames/translations).
+    Fallback: coverage-based auto-detection against *ref_arm_obj* — the MHWS
+              reference armature imported in Step 3 — requires ≥ 95 % coverage.
+    Returns the filename string (e.g. "怪猎荒野.json"), or None on failure.
+    """
+    import json as _json
+    from ...core.bone_mapper import auto_detect_preset
+
+    root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    bone_dir = os.path.join(root_dir, "assets", "presets", "bone")
+    if os.path.isdir(bone_dir):
+        for fname in sorted(os.listdir(bone_dir)):
+            if not fname.endswith('.json'):
+                continue
+            try:
+                with open(os.path.join(bone_dir, fname), encoding='utf-8') as fh:
+                    data = _json.load(fh)
+                if data.get('preset_info', {}).get('game_code') == 'MHWS':
+                    return fname
+            except Exception:
+                continue
+
+    # Fallback: coverage detection against the imported MHWS reference armature
+    if ref_arm_obj is not None:
+        return auto_detect_preset(ref_arm_obj, is_import_x=False)
+    return None
 
 
 def _detect_source_preset(source_arm_obj):
@@ -586,7 +615,6 @@ class MHWS_OT_PreprocessModel(bpy.types.Operator):
 
         settings.import_preset_enum = detected
         settings.pose_import_preset_enum = detected
-        settings.target_preset_enum = _PREPROCESS_Y_PRESET
 
         # Step 2: MMD only — 方向计算
         if detected == "MMD.json":
@@ -601,6 +629,13 @@ class MHWS_OT_PreprocessModel(bpy.types.Operator):
         mbt_panel.mhwilds_merge_facial_bones = True
         bpy.ops.mbt.import_mhwilds_fmesh()
         ref_arm_obj = _find_latest_mhwilds_armature()
+
+        # Detect Y (bone) preset: game_code first, then coverage fallback
+        y_preset = _detect_mhws_y_preset(ref_arm_obj)
+        if y_preset is None:
+            self.report({'WARNING'}, _("未能自动检测到荒野骨骼预设，请在面板中手动选择目标预设后重试"))
+            return {'CANCELLED'}
+        settings.target_preset_enum = y_preset
 
         scale = _calc_arm_scale(source_arm_obj, ref_arm_obj, detected)
         bpy.ops.object.mode_set(mode='OBJECT')

--- a/games/re4/batch_export.py
+++ b/games/re4/batch_export.py
@@ -114,6 +114,37 @@ def _do_export_fbxskel(filepath, armature_name):
     os.makedirs(os.path.dirname(filepath), exist_ok=True)
     bpy.ops.re_fbxskel.exportfile(filepath=filepath, targetArmature=armature_name)
 
+
+def _get_armature_from_collection(col_name):
+    if not col_name or col_name not in bpy.data.collections:
+        return None
+    arms = [o for o in bpy.data.collections[col_name].objects if o.type == 'ARMATURE']
+    return arms[0] if len(arms) == 1 else None
+
+
+def _find_body_arm_for_fbxskel(scene, scheme, use_simplified):
+    character_id = scheme["character_id"]
+    body_groups = scheme.get("body_groups_for_fbxskel", [])
+    groups_by_name = {g["name"]: g for g in scheme.get("groups", [])}
+    for group_name in body_groups:
+        col_name = None
+        if use_simplified:
+            col_name = _get_simplified_group_binding(scene, character_id, group_name, "mesh")
+        else:
+            group = groups_by_name.get(group_name)
+            if group:
+                for entry in group["entries"]:
+                    if entry.get("mesh"):
+                        binding = _get_binding(scene, character_id, entry["id"], "mesh")
+                        if binding:
+                            col_name = binding
+                            break
+        if col_name:
+            arm = _get_armature_from_collection(col_name)
+            if arm is not None:
+                return arm
+    return None
+
 def _get_blank_path(filetype, filename=None):
     """Return the path to a blank file in blank_files/re4/.
     If filename is given, use that directly; otherwise fall back to blank.<filetype>."""
@@ -155,6 +186,7 @@ class RE4_OT_BatchExport(bpy.types.Operator):
         base_path = scheme["base_path"].replace("\\", "/")
         use_simplified = scene.get("re4_use_simplified", True)
         use_blank = settings.re4_use_blank_export
+        use_body_arm = settings.re4_use_body_arm
 
         export_count = 0
         fail_count = 0
@@ -216,67 +248,12 @@ class RE4_OT_BatchExport(bpy.types.Operator):
                 print(f"[RE4] SKIP blank (file not found): {blank_src}")
                 skip_count += 1
 
-        # --- FBXSKEL ---
+        # 收集 fbxskel 配置（延迟到 mesh 之后执行）
         fbxskel_raw = scheme.get("fbxskel", "")
         fbxskel_paths = ([fbxskel_raw] if isinstance(fbxskel_raw, str) else list(fbxskel_raw))
         fbxskel_paths = [p for p in fbxskel_paths if p]
-        if fbxskel_paths:
-            fbx_enabled = _get_enabled(scene, character_id, "_fbxskel", "fbxskel")
-            fbx_arm = _get_binding(scene, character_id, "_fbxskel", "fbxskel")
-            if fbx_enabled and fbx_arm:
-                if settings.re4_use_fakebone:
-                    from .operators import do_fakebone, _get_native_skeletons_dir
-                    native_file = scheme.get("native_skeleton", "")
-                    if not native_file:
-                        self.report({'WARNING'}, "假头法: 未选择原生骨架，跳过 FBXSKEL")
-                        fail_count += 1
-                    else:
-                        native_path = os.path.join(_get_native_skeletons_dir(), native_file)
-                        if not os.path.isfile(native_path):
-                            self.report({'WARNING'}, f"假头法: 找不到原生骨架文件 {native_file}")
-                            fail_count += 1
-                        else:
-                            user_arm_obj = bpy.data.objects.get(fbx_arm)
-                            if user_arm_obj is None:
-                                self.report({'WARNING'}, f"假头法: 骨架对象 '{fbx_arm}' 不存在")
-                                fail_count += 1
-                            else:
-                                # 在副本上操作，不修改原骨架
-                                prev_active = context.view_layer.objects.active
-                                prev_sel = [o for o in context.selected_objects]
-                                prev_hidden = user_arm_obj.hide_viewport
-                                for o in prev_sel:
-                                    o.select_set(False)
-                                user_arm_obj.hide_viewport = False
-                                context.view_layer.objects.active = user_arm_obj
-                                user_arm_obj.select_set(True)
-                                bpy.ops.object.duplicate()
-                                arm_copy = context.active_object
-                                user_arm_obj.hide_viewport = prev_hidden
-                                user_arm_obj.select_set(False)
-                                if arm_copy is None:
-                                    self.report({'WARNING'}, f"假头法: duplicate 失败，无法获取副本对象")
-                                    fail_count += 1
-                                else:
-                                    try:
-                                        do_fakebone(context, arm_copy, native_path)
-                                        for fbxskel_path in fbxskel_paths:
-                                            full = os.path.join(natives_root, "natives", "STM", fbxskel_path.replace("/", os.sep))
-                                            try_export(_do_export_fbxskel, full, arm_copy.name, f"FBXSKEL (假头法) {os.path.basename(fbxskel_path)}")
-                                    except Exception as err:
-                                        print(f"[RE4] FAILED FBXSKEL (假头法): {err}")
-                                        fail_count += 1
-                                    finally:
-                                        if arm_copy is not None and arm_copy.name in bpy.data.objects:
-                                            bpy.data.objects.remove(arm_copy, do_unlink=True)
-                                        context.view_layer.objects.active = prev_active
-                                        for o in prev_sel:
-                                            if o.name in bpy.data.objects:
-                                                o.select_set(True)
-                else:
-                    for fbxskel_path in fbxskel_paths:
-                        full = os.path.join(natives_root, "natives", "STM", fbxskel_path.replace("/", os.sep))
-                        try_export(_do_export_fbxskel, full, fbx_arm, f"FBXSKEL {os.path.basename(fbxskel_path)}")
+        fbx_enabled = _get_enabled(scene, character_id, "_fbxskel", "fbxskel")
+        fbx_arm = _get_binding(scene, character_id, "_fbxskel", "fbxskel")
 
         # --- Per entry ---
         for group in scheme["groups"]:
@@ -360,6 +337,105 @@ class RE4_OT_BatchExport(bpy.types.Operator):
                             try_export(_do_export_chain, make_full(entry["chain"], grp_bp), chain_col, f"CHAIN {entry_id}")
                         elif chain_en and use_blank:
                             try_blank("chain", make_full(entry["chain"], grp_bp), f"CHAIN {entry_id}")
+
+        # --- FBXSKEL（在 mesh 之后执行，借助 mesh 导出对骨架唯一性的校验）---
+        if fbxskel_paths and fbx_enabled:
+            if use_body_arm:
+                from .operators import do_fakebone, _get_native_skeletons_dir
+                from ...core.bone_utils import align_armatures_by_name
+                native_file = scheme.get("native_skeleton", "")
+                if not native_file:
+                    self.report({'WARNING'}, "使用身体骨架: 预设未配置 native_skeleton，跳过 FBXSKEL")
+                    fail_count += 1
+                else:
+                    native_path = os.path.join(_get_native_skeletons_dir(), native_file)
+                    if not os.path.isfile(native_path):
+                        self.report({'WARNING'}, f"使用身体骨架: 找不到原生骨架文件 {native_file}")
+                        fail_count += 1
+                    else:
+                        body_arm_obj = _find_body_arm_for_fbxskel(scene, scheme, use_simplified)
+                        if body_arm_obj is not None:
+                            prev_active = context.view_layer.objects.active
+                            prev_sel = [o for o in context.selected_objects]
+                            for o in prev_sel:
+                                o.select_set(False)
+                            native_copy = None
+                            try:
+                                bpy.ops.re_fbxskel.importfile(filepath=native_path)
+                                native_copy = context.active_object
+                                if native_copy is None or native_copy.type != 'ARMATURE':
+                                    raise RuntimeError(f"导入原生骨架失败: {native_path}")
+                                native_copy.select_set(False)
+                                align_armatures_by_name(body_arm_obj, native_copy, mode='FULL')
+                                if settings.re4_use_fakebone:
+                                    do_fakebone(context, native_copy, native_path)
+                                label_prefix = "FBXSKEL (身体骨架+假头法)" if settings.re4_use_fakebone else "FBXSKEL (身体骨架)"
+                                for fbxskel_path in fbxskel_paths:
+                                    full = os.path.join(natives_root, "natives", "STM", fbxskel_path.replace("/", os.sep))
+                                    try_export(_do_export_fbxskel, full, native_copy.name, f"{label_prefix} {os.path.basename(fbxskel_path)}")
+                            except Exception as err:
+                                print(f"[RE4] FAILED FBXSKEL (身体骨架): {err}")
+                                fail_count += 1
+                            finally:
+                                if native_copy is not None and native_copy.name in bpy.data.objects:
+                                    bpy.data.objects.remove(native_copy, do_unlink=True)
+                                context.view_layer.objects.active = prev_active
+                                for o in prev_sel:
+                                    if o.name in bpy.data.objects:
+                                        o.select_set(True)
+            elif fbx_arm:
+                if settings.re4_use_fakebone:
+                    from .operators import do_fakebone, _get_native_skeletons_dir
+                    native_file = scheme.get("native_skeleton", "")
+                    if not native_file:
+                        self.report({'WARNING'}, "假头法: 未选择原生骨架，跳过 FBXSKEL")
+                        fail_count += 1
+                    else:
+                        native_path = os.path.join(_get_native_skeletons_dir(), native_file)
+                        if not os.path.isfile(native_path):
+                            self.report({'WARNING'}, f"假头法: 找不到原生骨架文件 {native_file}")
+                            fail_count += 1
+                        else:
+                            user_arm_obj = bpy.data.objects.get(fbx_arm)
+                            if user_arm_obj is None:
+                                self.report({'WARNING'}, f"假头法: 骨架对象 '{fbx_arm}' 不存在")
+                                fail_count += 1
+                            else:
+                                prev_active = context.view_layer.objects.active
+                                prev_sel = [o for o in context.selected_objects]
+                                prev_hidden = user_arm_obj.hide_viewport
+                                for o in prev_sel:
+                                    o.select_set(False)
+                                user_arm_obj.hide_viewport = False
+                                context.view_layer.objects.active = user_arm_obj
+                                user_arm_obj.select_set(True)
+                                bpy.ops.object.duplicate()
+                                arm_copy = context.active_object
+                                user_arm_obj.hide_viewport = prev_hidden
+                                user_arm_obj.select_set(False)
+                                if arm_copy is None:
+                                    self.report({'WARNING'}, "假头法: duplicate 失败，无法获取副本对象")
+                                    fail_count += 1
+                                else:
+                                    try:
+                                        do_fakebone(context, arm_copy, native_path)
+                                        for fbxskel_path in fbxskel_paths:
+                                            full = os.path.join(natives_root, "natives", "STM", fbxskel_path.replace("/", os.sep))
+                                            try_export(_do_export_fbxskel, full, arm_copy.name, f"FBXSKEL (假头法) {os.path.basename(fbxskel_path)}")
+                                    except Exception as err:
+                                        print(f"[RE4] FAILED FBXSKEL (假头法): {err}")
+                                        fail_count += 1
+                                    finally:
+                                        if arm_copy is not None and arm_copy.name in bpy.data.objects:
+                                            bpy.data.objects.remove(arm_copy, do_unlink=True)
+                                        context.view_layer.objects.active = prev_active
+                                        for o in prev_sel:
+                                            if o.name in bpy.data.objects:
+                                                o.select_set(True)
+                else:
+                    for fbxskel_path in fbxskel_paths:
+                        full = os.path.join(natives_root, "natives", "STM", fbxskel_path.replace("/", os.sep))
+                        try_export(_do_export_fbxskel, full, fbx_arm, f"FBXSKEL {os.path.basename(fbxskel_path)}")
 
         if fail_count > 0:
             self.report({'WARNING'}, f"Done: {export_count} exported, {fail_count} failed, {skip_count} skipped")

--- a/games/re4/batch_export_ui.py
+++ b/games/re4/batch_export_ui.py
@@ -348,10 +348,11 @@ class RE4_OT_BatchExportDialog(bpy.types.Operator):
             op.character_id = character_id; op.entry_id = "_fbxskel"; op.suffix = "fbxskel"
             fbx_label = f"FBXSKEL (×{len(fbxskel_paths)})" if len(fbxskel_paths) > 1 else "FBXSKEL"
             row.label(text=fbx_label, icon='ARMATURE_DATA')
-            cur_arm = _get_binding(scene, character_id, "_fbxskel", "fbxskel")
-            op_p = row.operator("re4.pick_armature", text=cur_arm if cur_arm else "Select armature...",
-                                icon='DOWNARROW_HLT')
-            op_p.character_id = character_id
+            if not settings.re4_use_body_arm:
+                cur_arm = _get_binding(scene, character_id, "_fbxskel", "fbxskel")
+                op_p = row.operator("re4.pick_armature", text=cur_arm if cur_arm else "Select armature...",
+                                    icon='DOWNARROW_HLT')
+                op_p.character_id = character_id
             # 假头法
             row2 = box.row(align=True)
             row2.prop(settings, "re4_use_fakebone", icon='BONE_DATA')
@@ -361,6 +362,15 @@ class RE4_OT_BatchExportDialog(bpy.types.Operator):
                     row2.label(text=native_skel, icon='FILE')
                 else:
                     row2.label(text="预设未配置 native_skeleton", icon='ERROR')
+            # 使用身体骨架
+            row3 = box.row(align=True)
+            row3.prop(settings, "re4_use_body_arm", icon='ARMATURE_DATA')
+            if settings.re4_use_body_arm:
+                body_groups = scheme.get("body_groups_for_fbxskel", [])
+                if body_groups:
+                    row3.label(text=" > ".join(body_groups), icon='INFO')
+                else:
+                    row3.label(text="预设未配置 body_groups_for_fbxskel", icon='ERROR')
 
         layout.separator()
         layout.prop(settings, "re4_use_blank_export", icon='FILE_BLANK')

--- a/ui/main_panel.py
+++ b/ui/main_panel.py
@@ -202,6 +202,11 @@ class MHW_PT_SuiteSettings(bpy.types.PropertyGroup):
         description="导出 fbxskel 前自动生成身体+手指 End 骨骼（原生骨架由预设 native_skeleton 字段指定）",
         default=False,
     )
+    re4_use_body_arm: bpy.props.BoolProperty(
+        name="使用身体骨架",
+        description="自动从身体 Mesh 集合获取骨架并对齐原生骨架，省去手动绑定 fbxskel 骨架",
+        default=False,
+    )
 
 
 class MHW_OT_GeneralTools(bpy.types.Operator):


### PR DESCRIPTION
This pull request introduces a new workflow for exporting FBX skeletons (fbxskel) for Resident Evil 4 characters by allowing automatic detection and use of the body armature directly from the character's mesh collections. This streamlines the export process by reducing manual steps, improves reliability, and enhances the UI to support the new feature. Additionally, it includes a robust preset detection mechanism for Monster Hunter Wilds bone presets and a minor improvement for bone name mirroring.

**RE4 batch export: Body armature auto-detection and workflow improvements**

* Added support for automatically finding and using the body armature for fbxskel export, based on new `body_groups_for_fbxskel` fields in the export schemes (`re4_ada.json`, `re4_ashley.json`, `re4_leon.json`). This removes the need to manually bind the fbxskel armature and ensures the correct skeleton is always used. [[1]](diffhunk://#diff-1edbc3a9ffb22a1fd177460b7229e6581c531d3c5fb3bb9b520fcda15db2b475R117-R147) [[2]](diffhunk://#diff-1edbc3a9ffb22a1fd177460b7229e6581c531d3c5fb3bb9b520fcda15db2b475R341-R439) [[3]](diffhunk://#diff-1edbc3a9ffb22a1fd177460b7229e6581c531d3c5fb3bb9b520fcda15db2b475R189) [[4]](diffhunk://#diff-8a735b0976d71ce37d45e2a9fb3bff4e0dcda64093509288fe021cf13ff77ea1R365-R373) [[5]](diffhunk://#diff-f674a81585f0cc86ea7fcd20783e4d0e84d70f4414b205f23b068072a756558fR205-R209) [[6]](diffhunk://#diff-013f575f97ed31e2bc34c3903d49358ffe21776a0bfcd2a30e6d3e301e32e42eR10) [[7]](diffhunk://#diff-4d2704eab5fc24dda39ecbdf50b039ba11c567b1aefc6f4426387dfe298bfe00R10) [[8]](diffhunk://#diff-148ed292c1e631442dc5c4d6f6e7caa5638153bc145c8b6880e8a46f4763d88cR7)
* The batch export logic now tries to use the body armature first (if enabled), falling back to manual selection if necessary. The process aligns the native skeleton to the detected body armature and supports the "fakebone" workflow as well. [[1]](diffhunk://#diff-1edbc3a9ffb22a1fd177460b7229e6581c531d3c5fb3bb9b520fcda15db2b475R341-R439) [[2]](diffhunk://#diff-1edbc3a9ffb22a1fd177460b7229e6581c531d3c5fb3bb9b520fcda15db2b475L219-L279)
* The UI (`batch_export_ui.py`) has been updated to add a toggle for "使用身体骨架" (Use Body Armature), display the configured body groups, and hide the manual armature picker when this mode is active. [[1]](diffhunk://#diff-8a735b0976d71ce37d45e2a9fb3bff4e0dcda64093509288fe021cf13ff77ea1R351) [[2]](diffhunk://#diff-8a735b0976d71ce37d45e2a9fb3bff4e0dcda64093509288fe021cf13ff77ea1R365-R373) [[3]](diffhunk://#diff-f674a81585f0cc86ea7fcd20783e4d0e84d70f4414b205f23b068072a756558fR205-R209)

**Monster Hunter Wilds: Bone preset detection improvements**

* Replaced the hardcoded preset filename for MHWS bone mapping with a function that detects the correct preset based on `game_code` in the preset JSON, with a fallback to coverage-based auto-detection. This improves robustness against file renames and translations. [[1]](diffhunk://#diff-1799ae50cebe39ba727e74908b9fa63d04b99ac30a5364b0eada3f1330863d8cL468-R497) [[2]](diffhunk://#diff-1799ae50cebe39ba727e74908b9fa63d04b99ac30a5364b0eada3f1330863d8cL589) [[3]](diffhunk://#diff-1799ae50cebe39ba727e74908b9fa63d04b99ac30a5364b0eada3f1330863d8cR633-R639)

**Other improvements**

* Improved the bone name mirroring utility to handle `L_`/`l_` prefix styles used in RE Engine and HD2, making bone alignment more robust.